### PR TITLE
Update: pcNet Sparse SVD Solver

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -56,5 +56,5 @@ dependencies:
   - scanpy>=1.7.2
   - ray # https://docs.ray.io/en/latest/ray-overview/installation.html
   - notebook
-name: scTenifold2
+name: scTenifold
 

--- a/environment.yml
+++ b/environment.yml
@@ -56,5 +56,5 @@ dependencies:
   - scanpy>=1.7.2
   - ray # https://docs.ray.io/en/latest/ray-overview/installation.html
   - notebook
-name: scTenifold
+name: scTenifold2
 

--- a/scTenifoldXct/pcNet.py
+++ b/scTenifoldXct/pcNet.py
@@ -5,7 +5,6 @@ from sklearn.preprocessing import normalize
 import os
 import time
 import ray
-from tqdm import tqdm
 
 
 def pcCoefficients(X, K, nComp):
@@ -41,7 +40,7 @@ def pcNet(X, # X: cell * gene
     else:
         np.random.seed(random_state)
         n = X.shape[1] # genes    
-        B = np.array([pcCoefficients(X, k, nComp) for k in tqdm(range(n))])    
+        B = np.array([pcCoefficients(X, k, nComp) for k in range(n)])    
         A = np.ones((n, n), dtype=float)
         np.fill_diagonal(A, 0)
         for i in range(n):


### PR DESCRIPTION
## Fixes
- The numpy SVD solver for pcNet construction has been swaped by the scipy.sparse.linalg.svds which is much faster.
- Data standardization has been added to replicate data normalization in the original R code by D. Osorio.