### PR TITLE
Refactor: decouple internals, fix latent bugs

### DIFF
--- a/scTenifoldXct/__init__.py
+++ b/scTenifoldXct/__init__.py
@@ -1,8 +1,16 @@
 import logging
 
-from .version import __version__  # noqa: F401
+from .version import __version__
 from scTenifoldXct.core import scTenifoldXct
 from scTenifoldXct.visualization import get_Xct_pairs, plot_XNet
 from scTenifoldXct.merge import merge_scTenifoldXct
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+__all__ = [
+    "__version__",
+    "scTenifoldXct",
+    "merge_scTenifoldXct",
+    "get_Xct_pairs",
+    "plot_XNet",
+]

--- a/scTenifoldXct/cko.py
+++ b/scTenifoldXct/cko.py
@@ -8,12 +8,21 @@ logger = logging.getLogger(__name__)
 
 def get_cko_data(data: anndata.AnnData, cko_gene_names: Union[List[str], str]) -> anndata.AnnData:
     """
-    Get the adata with the cko genes.
+    Return a copy of ``data`` with the conditional-knockout genes zeroed out.
+
+    Gene names are upper-cased to match the convention used throughout the
+    package (scTenifoldXct and the LR/TF databases). The input AnnData is not
+    modified in place.
     """
-    cko_gene_names = [cko_gene_names.lower()] if isinstance(cko_gene_names, str) else [gene.lower() for gene in cko_gene_names]
-    data.var_names = data.var_names.str.lower()
+    if isinstance(cko_gene_names, str):
+        cko_gene_names = [cko_gene_names.upper()]
+    else:
+        cko_gene_names = [gene.upper() for gene in cko_gene_names]
+
+    data = data.copy()
+    data.var_names = data.var_names.str.upper()
     gene_index = [data.var_names.get_loc(gene_name) for gene_name in cko_gene_names]
     data.X[:, gene_index] = 0.
     logger.info(f"CKO genes {cko_gene_names} are set")
-    
+
     return data

--- a/scTenifoldXct/core.py
+++ b/scTenifoldXct/core.py
@@ -296,12 +296,31 @@ class scTenifoldXct:
         return self._net_B
 
     @property
+    def cell_names(self):
+        """[source_celltype, target_celltype]."""
+        return self._cell_names
+
+    @property
+    def genes(self):
+        """Mapping of cell-type name -> gene-name Index."""
+        return self._genes
+
+    @property
+    def cell_data(self):
+        """Mapping of cell-type name -> per-cell-type AnnData view."""
+        return self._cell_data_dic
+
+    @property
     def aligned_dist(self):
         if self._aligned_result is None:
             raise AttributeError("No aligned_dist created yet. "
                                  "Please call train_nn() to train the neural network to get embeddings first.")
 
         return self._aligned_result
+
+    def get_data_arr(self):
+        """Return a list of expression arrays (gene x cell) per cell type."""
+        return self._get_data_arr()
 
     def copy(self):
         from copy import deepcopy
@@ -388,9 +407,9 @@ class scTenifoldXct:
                          alpha * (self._build_metric_vec(dic=self._cell_metric_dict[ligand]["var"],
                                                          gene_names=self._genes[ligand])))[:, None]
         metric_b_temp = ((1 - alpha) * np.square(self._build_metric_vec(dic=self._cell_metric_dict[receptor]["mean"],
-                                                                        gene_names=self._genes[ligand])) +
+                                                                        gene_names=self._genes[receptor])) +
                          alpha * (self._build_metric_vec(dic=self._cell_metric_dict[receptor]["var"],
-                                                         gene_names=self._genes[ligand])))[:, None]
+                                                         gene_names=self._genes[receptor])))[:, None]
         w12 = metric_a_temp @ metric_b_temp.T
         net_A, net_B = self._net_A.net.toarray()+1, self._net_B.net.toarray()+1
         del metric_a_temp

--- a/scTenifoldXct/merge.py
+++ b/scTenifoldXct/merge.py
@@ -2,13 +2,11 @@ import logging
 
 import numpy as np
 import pandas as pd
-import scipy
 from scipy import sparse
 
 from .core import scTenifoldXct
 from .nn import ManifoldAlignmentNet
 from .stat import chi2_diff_test
-from .visualization import plot_pcNet_method
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +16,7 @@ class merge_scTenifoldXct:
                 *Xcts: scTenifoldXct, 
                 verbose: bool = True):
         self.Xcts = Xcts
-        self._merge_candidates = list(set(self.Xcts[0]._candidates).union(set(self.Xcts[1]._candidates)))
+        self._merge_candidates = list(set(self.Xcts[0].candidates).union(set(self.Xcts[1].candidates)))
         self.verbose = verbose
         self.n_dim = 3
         self.mu = 0.9
@@ -34,22 +32,18 @@ class merge_scTenifoldXct:
         if self.verbose:
             logger.info("merge_scTenifoldXct init completed")
 
-    def _get_data_arrs(self):  
+    def _get_data_arrs(self):
         '''return a list of counts in numpy array, gene by cell'''
-        data_arr_A = [cell_data.X.T.toarray() if scipy.sparse.issparse(cell_data.X) else cell_data.X.T   # gene by cell
-                    for _, cell_data in self.Xcts[0]._cell_data_dic.items()]
-        data_arr_B = [cell_data.X.T.toarray() if scipy.sparse.issparse(cell_data.X) else cell_data.X.T   # gene by cell
-                    for _, cell_data in self.Xcts[1]._cell_data_dic.items()]
-        return data_arr_A + data_arr_B  # a list
+        return self.Xcts[0].get_data_arr() + self.Xcts[1].get_data_arr()
 
     def _build_W(self):
         '''build a cross-object corresponding matrix for further differential analysis'''
-        W12 = np.zeros((self.Xcts[0]._w.shape[0], self.Xcts[1]._w.shape[1]), float)
-        scaled_diag = self.mu * ((self.Xcts[0]._w).sum() + (self.Xcts[1]._w).sum()) / (4 * len(W12)) 
+        w_A, w_B = self.Xcts[0].w, self.Xcts[1].w
+        W12 = np.zeros((w_A.shape[0], w_B.shape[1]), float)
+        scaled_diag = self.mu * (w_A.sum() + w_B.sum()) / (4 * len(W12))
         np.fill_diagonal(W12, scaled_diag)
-        # W12 = W12.todok()
-        W = sparse.vstack([sparse.hstack([self.Xcts[0]._w, W12]),
-            sparse.hstack([W12.T, self.Xcts[1]._w])])      
+        W = sparse.vstack([sparse.hstack([w_A, W12]),
+                           sparse.hstack([W12.T, w_B])])
         return W, W12.shape
 
     @property
@@ -94,20 +88,21 @@ class merge_scTenifoldXct:
                     ):
         '''pair-wise difference of aligned distance'''
         projections_split = np.array_split(merge_projections, 2)
-        self._aligned_result_A = self.Xcts[0]._nn_trainer.nn_aligned_dist(projections_split[0],
-                                                                gene_names_x=self.Xcts[0]._genes[self.Xcts[0]._cell_names[0]],
-                                                                gene_names_y=self.Xcts[0]._genes[self.Xcts[0]._cell_names[1]],
-                                                                w12_shape=self.Xcts[0].w12_shape,
-                                                                dist_metric=dist_metric,
-                                                                rank=rank,
-                                                                verbose=self.verbose)
-        self._aligned_result_B = self.Xcts[1]._nn_trainer.nn_aligned_dist(projections_split[1],
-                                                                gene_names_x=self.Xcts[1]._genes[self.Xcts[1]._cell_names[0]],
-                                                                gene_names_y=self.Xcts[1]._genes[self.Xcts[1]._cell_names[1]],
-                                                                w12_shape=self.Xcts[1].w12_shape,
-                                                                dist_metric=dist_metric,
-                                                                rank=rank,
-                                                                verbose=self.verbose)
+        xct_A, xct_B = self.Xcts[0], self.Xcts[1]
+        self._aligned_result_A = xct_A.trainer.nn_aligned_dist(projections_split[0],
+                                                               gene_names_x=xct_A.genes[xct_A.cell_names[0]],
+                                                               gene_names_y=xct_A.genes[xct_A.cell_names[1]],
+                                                               w12_shape=xct_A.w12_shape,
+                                                               dist_metric=dist_metric,
+                                                               rank=rank,
+                                                               verbose=self.verbose)
+        self._aligned_result_B = xct_B.trainer.nn_aligned_dist(projections_split[1],
+                                                               gene_names_x=xct_B.genes[xct_B.cell_names[0]],
+                                                               gene_names_y=xct_B.genes[xct_B.cell_names[1]],
+                                                               w12_shape=xct_B.w12_shape,
+                                                               dist_metric=dist_metric,
+                                                               rank=rank,
+                                                               verbose=self.verbose)
         df_nn_all = pd.concat([self._aligned_result_A, self._aligned_result_B.drop(['ligand', 'receptor'], axis=1)], axis=1) 
         # print('adding column \'diff2\'...')
         df_nn_all['diff2'] = np.square(df_nn_all['dist'].iloc[:, 0] - df_nn_all['dist'].iloc[:, 1]) #there are two 'dist' cols
@@ -140,19 +135,6 @@ class merge_scTenifoldXct:
                                  "Please call train_nn() to train the neural network to get embeddings first.")
         return self._aligned_diff_result
 
-    # def plot_merge_pcNet_graph(self, 
-    #                         gene_names: list[str], 
-    #                         sample: int = 0, 
-    #                         view: str ="sender", 
-    #                         **kwargs):
-    #     if view not in ["sender", "receiver"]:
-    #         raise ValueError("view needs to be sender or receiver")
-
-    #     g = plot_pcNet_method(self.Xcts[sample]._net_A if view == "sender" else self.Xcts[sample]._net_B,
-    #                       gene_names=gene_names,
-    #                       tf_names=self.Xcts[sample]._TFs["TF_symbol"].to_list(),
-    #                       **kwargs)
-    #     return g
 
 def main(args):
     from time import time

--- a/scTenifoldXct/stat.py
+++ b/scTenifoldXct/stat.py
@@ -114,7 +114,7 @@ def null_test(df_nn: pd.DataFrame,
             pval=0.05, 
             plot=False):
     '''nonparametric left tail test to have enriched pairs'''
-    if ('dist' or 'correspondence') not in df_nn.columns:
+    if 'dist' not in df_nn.columns or 'correspondence' not in df_nn.columns:
         raise IndexError('require resulted dataframe with column \'dist\' and \'correspondence\'')
 
     else:

--- a/scTenifoldXct/visualization.py
+++ b/scTenifoldXct/visualization.py
@@ -1,9 +1,8 @@
+from collections import namedtuple
+
 import igraph as ig
 import numpy as np
-import pandas as pd
 import scipy.sparse
-import warnings
-from collections import namedtuple
 
 
 def get_Xct_pairs(df):
@@ -124,7 +123,7 @@ def plot_pcNet_method(net,
 
     kws = dict(visual_style_pcnet._asdict())
     kws.update(kwargs)
-    kws = _parse_kws(kws, g, bbox_scale, edge_width_scale)
+    kws = _parse_kws(kws, g, bbox_scale, edge_width_scale=edge_width_scale)
 
     if file_name is not None and verbose:
         print(f'graph saved as \"{file_name}\"')


### PR DESCRIPTION
Stage 3 - decouple:
- Add public accessors to scTenifoldXct: cell_names, genes, cell_data, get_data_arr(); add __all__ to package __init__
- Refactor merge.py to use public API instead of cross-object _private access; de-duplicate _get_data_arrs; drop dead commented code and now-unused scipy/plot_pcNet_method imports

Stage 4 - bug fixes (regression-gated, 12/12 pass):
- stat.py: fix ('dist' or 'correspondence') guard that always checked only 'dist'; now checks both columns
- core.py _build_w: index receptor metrics with _genes[receptor] not _genes[ligand] (zero numerical impact, correct-by-construction)
- visualization.py: edge_width_scale was passed positionally as g1; now passed as keyword
- cko.py: upper-case gene names to match core/database convention; copy input instead of mutating caller's AnnData in place